### PR TITLE
📦 Rename package to pydude

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ install:
 	pip install -U pip setuptools poetry
 	poetry install
 	poetry run playwright install
-	poetry run playwright install
 	poetry run playwright install-deps
 
 .PHONY: install-actions

--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ Contribute to this project by feature requests, idea discussions, reporting bugs
 
 ### Installation
 
+To install, simply run:
+
+```bash
+pip install pydude
+playwright install
+```
+
+The second command will install playwright binaries for Chrome, Firefox and Webkit. See https://playwright.dev/python/docs/intro#pip
+
 ### Example
 
 The included [examples/flat.py](examples/flat.py) code was written to scrape Google Search results ("q=dude"). You can run the example in your terminal using the command `python example.py`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "dude"
+name = "pydude"
 version = "0.1.0-alpha.0"
 repository = "https://github.com/roniemartinez/dude"
 description = "dude uncomplicated data extraction"
@@ -19,6 +19,9 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: Implementation :: CPython",
+]
+packages = [
+    { include = "dude" },
 ]
 
 [tool.poetry.urls]


### PR DESCRIPTION
Since the name that we want is already taken in PyPI, rename package to `pydude`. API usage will still be the same.